### PR TITLE
Fix compilation where ncurses is splitted

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -37,6 +37,7 @@ dnl Checks for libraries.
 AC_CHECK_LIB(curses, initscr, LIBS="$LIBS -lcurses",
   AC_CHECK_LIB(ncurses, initscr, LIBS="$LIBS -lncurses")
 )
+AC_CHECK_LIB(tinfo, keypad, LIBS="$LIBS -ltinfo")
 AC_CHECK_FUNC(use_default_colors, 
   AC_DEFINE(HAVE_COLORS, , "Define if you want colored (fruit salad) display option")
 )


### PR DESCRIPTION
Fix compilation on systems where ncurses is splitted in libncurses and libtinfo