### PR TITLE
Mark cursor position in both modes: HEX and ASCII

### DIFF
--- a/display.c
+++ b/display.c
@@ -112,6 +112,7 @@ void initCurses(void)
     init_pair(2, COLOR_GREEN, -1); /* control chars */
     init_pair(3, COLOR_BLUE, -1);  /* extended chars */
   }
+  init_pair(4, COLOR_BLUE, COLOR_YELLOW); /* current cursor position*/
 #endif
 
   refresh();
@@ -186,8 +187,10 @@ void display(void)
 
 void displayLine(int offset, int max)
 {
-  int i;
-
+  int i,mark_color=0;
+#ifdef HAVE_COLORS
+  mark_color = COLOR_PAIR(4) | A_BOLD;
+#endif
   PRINTW(("%08lX   ", (int) (base + offset)));
   for (i = offset; i < offset + lineLength; i++) {
     if (i > offset) MAXATTRPRINTW(bufferAttr[i] & MARKED, (((i - offset) % blocSize) ? " " : "  "));
@@ -195,9 +198,11 @@ void displayLine(int offset, int max)
       ATTRPRINTW(
 #ifdef HAVE_COLORS
 		 (!colored ? 0 :
+      (cursor == i && hexOrAscii == 0 ? mark_color :
 		  buffer[i] == 0 ? COLOR_PAIR(1) :
 		  buffer[i] < ' ' ? COLOR_PAIR(2) : 
-		  buffer[i] >= 127 ? COLOR_PAIR(3) : 0) |
+		  buffer[i] >= 127 ? COLOR_PAIR(3) : 0)
+      ) |
 #endif
 		 bufferAttr[i], ("%02X", buffer[i]));
     }
@@ -206,8 +211,8 @@ void displayLine(int offset, int max)
   PRINTW(("  "));
   for (i = offset; i < offset + lineLength; i++) {
     if (i >= max) PRINTW((" "));
-    else if (buffer[i] >= ' ' && buffer[i] < 127) ATTRPRINTW(bufferAttr[i], ("%c", buffer[i]));
-    else ATTRPRINTW(bufferAttr[i], ("."));
+    else if (buffer[i] >= ' ' && buffer[i] < 127) ATTRPRINTW((cursor == i && hexOrAscii==1 ? mark_color : 0) | bufferAttr[i], ("%c", buffer[i]));
+    else ATTRPRINTW((cursor == i && hexOrAscii == 1 ? mark_color : 0) | bufferAttr[i], ("."));
   }
 }
 

--- a/hexedit.c
+++ b/hexedit.c
@@ -29,6 +29,13 @@ int isReadOnly, fd, nbBytes, oldcursor, oldattr, oldcursorOffset;
 int sizeCopyBuffer, *bufferAttr;
 char *progName, *fileName, *baseName;
 unsigned char *buffer, *copyBuffer;
+
+unsigned char *diffBuffer;
+char *difffileName;
+INT diffFileSize;
+int difffd, diffnbBytes;
+
+
 typePage *edited;
 
 char *lastFindFile = NULL, *lastYankToAFile = NULL, *lastAskHexString = NULL, *lastAskAsciiString = NULL, *lastFillWithStringHexa = NULL, *lastFillWithStringAscii = NULL;
@@ -45,7 +52,8 @@ char * usage = "usage: %s [-s | --sector] [-m | --maximize] [-l<n> | --linelengt
 #ifdef HAVE_COLORS 
      " [--color]"
 #endif 
-     " [-h | --help] filename\n";
+     " [-h | --help] filename[ diffWithFile]\n"
+    "If you want mark differences between two files specify diffWithFile - only with --color\n";
 
 
 /*******************************************************************************/
@@ -56,7 +64,7 @@ int main(int argc, char **argv)
   progName = basename(argv[0]);
   argv++; argc--;
 
-  for (; argc > 0; argv++, argc--) 
+  for (; argc > 0; argv++, argc--)
     {
       if (streq(*argv, "-s") || streq(*argv, "--sector"))
 	mode = bySector;
@@ -83,13 +91,17 @@ int main(int argc, char **argv)
 	DIE(usage)
       else break;
     }
-  if (argc > 1) DIE(usage);
+  if (argc < 1) DIE(usage);
 
   init();
-  if (argc == 1) {
-    fileName = strdup(*argv); 
-    openFile();
+  fileName = strdup(*argv);
+  argv++; argc--;
+  openFile();
+  if(argc == 1){
+    difffileName = strdup(*argv);
+    openDiffFile();
   }
+
   initCurses();
   if (fileName == NULL) {
     if (!findFile()) {

--- a/hexedit.h
+++ b/hexedit.h
@@ -1,12 +1,14 @@
 #ifndef HEXEDIT_H
 #define HEXEDIT_H
 
+
 #include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <getopt.h>
 #if HAVE_FCNTL_H
 #include <fcntl.h>
 #endif
@@ -100,6 +102,11 @@ extern int isReadOnly, fd, nbBytes, oldcursor, oldattr, oldcursorOffset;
 extern int sizeCopyBuffer, *bufferAttr;
 extern char *progName, *fileName, *baseName;
 extern unsigned char *buffer, *copyBuffer;
+extern INT diffFileSize;
+extern unsigned char *diffBuffer;
+extern char *difffileName;
+extern int difffd, diffnbBytes;
+
 extern typePage *edited;
 
 extern char *lastFindFile, *lastYankToAFile, *lastAskHexString, *lastAskAsciiString, *lastFillWithStringHexa, *lastFillWithStringAscii;
@@ -115,6 +122,8 @@ void quit(void);
 int tryloc(INT loc);
 void openFile(void);
 void readFile(void);
+void openDiffFile(void);
+void readDiffFile(void);
 int findFile(void);
 int computeLineSize(void);
 int computeCursorXCurrentPos(void);


### PR DESCRIPTION
When editing file will be more friendly if cursor position will be marked in not active mode. So when your current mode is ASCII then current cursor position will be shown in HEX mode, and vice versa.