### PR TITLE
autotools / documentation corrections

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,4 +72,4 @@ $ac_includes_default
 #endif
 )
 
-AC_OUTPUT(Makefile Makefile-build)
+AC_OUTPUT(Makefile Makefile-build hexedit.1)

--- a/hexedit.1.in
+++ b/hexedit.1.in
@@ -225,9 +225,7 @@ You can find
 .I hexedit
 at 
 .br
-<http://rigaux.org/hexedit-VERSION.src.tgz> and 
-.br
-<http://rigaux.org/hexedit-VERSION.bin.i386.dynamic.tgz>.
+<https://github.com/pixel/hexedit/archive/@VERSION@.tar.gz>
 .SH TODO
 Anything you think could be nice...
 .SH LIMITATIONS


### PR DESCRIPTION
Corrected old deprecated name configure.in; since about the year 2001,
this file should now be named configure.ac.

Corrected location of source tarball in hexedit.1.in.

Modified configure.ac to properly build hexedit.1 from hexedit.1.in.