### PR TITLE
Fix error for configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,7 @@ AC_PROG_INSTALL
 
 dnl Checks for libraries.
 AC_CHECK_LIB(curses, initscr, LIBS="$LIBS -lcurses",
-  AC_CHECK_LIB(ncurses, initscr, LIBS="$LIBS -lncurses")
+  [AC_CHECK_LIB(ncurses, initscr, LIBS="$LIBS -lncurses")]
 )
 AC_CHECK_LIB(tinfo, keypad, LIBS="$LIBS -ltinfo")
 AC_CHECK_FUNC(use_default_colors, 


### PR DESCRIPTION
This pull request fix the following message when running the 'configure' command:

```
checking for initscr in -lcurses... ./configure: line 3115: ac_fn_c_try_link: command not found
no
```

Thanks!