### PR TITLE
Overflow on excessively long escape sequence.

### DIFF
--- a/interact.c
+++ b/interact.c
@@ -662,7 +662,7 @@ static void escaped_command(void)
     break;
 
   case '[': 
-    for (i = 0;; i++) { tmp[i] = c = getch(); if (!isdigit(c)) break; }
+    for (i = 0; i < sizeof(tmp) - 1; i++) { tmp[i] = c = getch(); if (!isdigit(c)) break; }
     tmp[i + 1] = '\0';
     
     if (0);


### PR DESCRIPTION
If a terminal escape sequence is longer than 4096 characters
a stack overflow occurs in escaped_command.

It is unlikely that this happens and I cannot consider this a
security issue. First of all, if an attacker can send terminal
escape sequences, it would be probably easier to send input to
a running terminal. Or open files with hexedit for manipulation
anyway.

Also the attacker is limited to digits in their ASCII form
and an arbitrary byte followed by a \0. It's easy to crash the
program, but very hard to inject a useful ROP sequence.

It should still be fixed though, because hexedit allows the
execution of child processes (due to man support) and it's a
theoretical stability issue.

How to repeat: Enter ^[ (ctrl + [), [, and then > 4096 digits.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>