### PR TITLE
Ignore KEY_RESIZE in main loop.

### DIFF
--- a/interact.c
+++ b/interact.c
@@ -342,6 +342,7 @@ int key_to_function(int key)
   switch (key)
     {
     case ERR:
+    case KEY_RESIZE:
       /*no-op*/
       break;
 
@@ -529,9 +530,6 @@ int key_to_function(int key)
     case KEY_F(10):
     case CTRL('X'):
       ask_about_save_and_quit();
-      break;
-
-    case KEY_RESIZE:
       break;
 
     default:

--- a/interact.c
+++ b/interact.c
@@ -531,6 +531,9 @@ int key_to_function(int key)
       ask_about_save_and_quit();
       break;
 
+    case KEY_RESIZE:
+      break;
+
     default:
       if ((key >= 256 || !setTo(key))) firstTimeHelp();
     }


### PR DESCRIPTION
The KEY_RESIZE key can be encountered while resizing the terminal
running hexedit.

As the resizing is handled in an own signal handler, and because
this key is not mapped, ignore it in key_to_function so no
error message is shown.

As a side note: The signal handler is not thread-safe, but that
is a subject for another patch.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>