### PR TITLE
Do not allow negative line length.

### DIFF
--- a/hexedit.c
+++ b/hexedit.c
@@ -75,6 +75,8 @@ int main(int argc, char **argv)
 	  argv++; argc--;
 	  lineLength = atoi(*argv);
 	}
+	if (lineLength < 0 || lineLength > 4096)
+	  DIE("illegal line length\n")
       } else if (streq(*argv, "--")) {
 	argv++; argc--;
 	break;


### PR DESCRIPTION
Supplying a negative line length results in illegal memory access
while parsing the input file (the memset that is supposed to clear
the memory triggers an out of boundary write).

While at it, also prevent line length to become too large. It is
used in a multiplication with LINES during page calculation. If
in doubt, you can increase that limit of course.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>