### PR TITLE
Keep status of firstTime beween calls.

### DIFF
--- a/interact.c
+++ b/interact.c
@@ -179,7 +179,7 @@ static void truncate_file(void)
 
 static void firstTimeHelp(void)
 {
-  int firstTime = TRUE;
+  static int firstTime = TRUE;
 
   if (firstTime) {
     firstTime = FALSE;


### PR DESCRIPTION
It seems that firstTime was supposed to keep status if first
time help has been already shown. For that, the variable must
be static.

clang warns about this when running static analyzer as well.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>