### PR TITLE
Fix compiler warnings and off_t handling on 32 bit

### DIFF
--- a/display.c
+++ b/display.c
@@ -203,10 +203,10 @@ void display(void)
   if (isReadOnly) i = '%';
   else if (edited) i = '*';
   else i = '-';
-  printw("-%c%c  %s       --0x%llX", i, i, baseName, base + cursor);
-  if (MAX(fileSize, lastEditedLoc)) printw("/0x%llX", getfilesize());
+  printw("-%c%c  %s       --0x%llX", i, i, baseName, (long long) base + cursor);
+  if (MAX(fileSize, lastEditedLoc)) printw("/0x%llX", (long long) getfilesize());
   printw("--%i%%", 100 * (base + cursor + getfilesize()/200) / getfilesize() );
-  if (mode == bySector) printw("--sector %lld", (base + cursor) / SECTOR_SIZE);
+  if (mode == bySector) printw("--sector %lld", (long long) ((base + cursor) / SECTOR_SIZE));
 
   move(cursor / lineLength, computeCursorXCurrentPos());
 }
@@ -301,14 +301,18 @@ void ungetstr(char *s)
 
 int get_number(INT *i)
 {
+  unsigned long long n;
   int err;
   char tmp[BLOCK_SEARCH_SIZE];
   echo();
   getnstr(tmp, BLOCK_SEARCH_SIZE - 1);
   noecho();
   if (strbeginswith(tmp, "0x"))
-    err = sscanf(tmp + strlen("0x"), "%llx", i);
+    err = sscanf(tmp + strlen("0x"), "%llx", &n);
   else
-    err = sscanf(tmp, "%lld", i);
+    err = sscanf(tmp, "%llu", &n);
+  *i = (off_t)n;
+  if (*i < 0 || n != (unsigned long long) *i)
+    err = 0;
   return err == 1;
 }

--- a/display.c
+++ b/display.c
@@ -225,9 +225,9 @@ void displayLine(int offset, int max)
 #ifdef HAVE_COLORS
 		 (!colored ? 0 :
       (cursor == i && hexOrAscii == 0 ? mark_color :
-		  buffer[i] == 0 ? COLOR_PAIR(1) :
-		  buffer[i] < ' ' ? COLOR_PAIR(2) : 
-		  buffer[i] >= 127 ? COLOR_PAIR(3) : 0)
+		  buffer[i] == 0 ? (int) COLOR_PAIR(1) :
+		  buffer[i] < ' ' ? (int) COLOR_PAIR(2) :
+		  buffer[i] >= 127 ? (int) COLOR_PAIR(3) : 0)
       ) |
 #endif
 		 bufferAttr[i], ("%02X", buffer[i]));

--- a/hexedit.c
+++ b/hexedit.c
@@ -76,7 +76,7 @@ int main(int argc, char **argv)
 	  lineLength = atoi(*argv);
 	}
 	if (lineLength < 0 || lineLength > 4096)
-	  DIE("illegal line length\n")
+	  DIE("%s: illegal line length\n")
       } else if (streq(*argv, "--")) {
 	argv++; argc--;
 	break;

--- a/interact.c
+++ b/interact.c
@@ -663,7 +663,7 @@ static void escaped_command(void)
     break;
 
   case '[': 
-    for (i = 0; i < sizeof(tmp) - 1; i++) { tmp[i] = c = getch(); if (!isdigit(c)) break; }
+    for (i = 0; i < BLOCK_SEARCH_SIZE - 1; i++) { tmp[i] = c = getch(); if (!isdigit(c)) break; }
     tmp[i + 1] = '\0';
     
     if (0);


### PR DESCRIPTION
While investigating compiler warnings I encountered a bad DIE message which I introduced yesterday (sorry for that!) and an issue that arises when compiling hexedit with --disable-largefile on a 32 bit system.

The code assumes that off_t is always 64 bit, which is not always the case on 32 bit systems -- but almost always. In either way, hexedit works in that scenario as expected now.

The only shown warning is left in the signal handler because signo is not used. As stated in a previous message, the signal handler is a subject for its own patch.