### PR TITLE
Added note and colour tagging functionality

### DIFF
--- a/display.c
+++ b/display.c
@@ -207,6 +207,7 @@ void display(void)
   if (MAX(fileSize, lastEditedLoc)) printw("/0x%llX", (long long) getfilesize());
   printw("--%i%%", 100 * (base + cursor + getfilesize()/200) / getfilesize() );
   if (mode == bySector) printw("--sector %lld", (long long) ((base + cursor) / SECTOR_SIZE));
+  if (notes[base+cursor].note) printw("--note: %s", notes[base+cursor].note);
 
   move(cursor / lineLength, computeCursorXCurrentPos());
 }

--- a/display.c
+++ b/display.c
@@ -131,6 +131,9 @@ void initCurses(void)
     init_pair(1, COLOR_RED, -1);   /* null zeros */
     init_pair(2, COLOR_GREEN, -1); /* control chars */
     init_pair(3, COLOR_BLUE, -1);  /* extended chars */
+    init_pair(5, COLOR_CYAN, -1);  /* custom tag color */
+    init_pair(6, COLOR_MAGENTA, -1); /* custom tag color */
+    init_pair(7, COLOR_YELLOW, -1);  /* custom tag color */
   }
   init_pair(4, COLOR_BLUE, COLOR_YELLOW); /* current cursor position*/
 #endif
@@ -207,7 +210,7 @@ void display(void)
   if (MAX(fileSize, lastEditedLoc)) printw("/0x%llX", (long long) getfilesize());
   printw("--%i%%", 100 * (base + cursor + getfilesize()/200) / getfilesize() );
   if (mode == bySector) printw("--sector %lld", (long long) ((base + cursor) / SECTOR_SIZE));
-  if (notes[base+cursor].note) printw("--note: %s", notes[base+cursor].note);
+  if (notes_size >= (base+cursor)) if (notes[base+cursor].note) printw("--note: %s", notes[base+cursor].note);
 
   move(cursor / lineLength, computeCursorXCurrentPos());
 }
@@ -226,6 +229,7 @@ void displayLine(int offset, int max)
 #ifdef HAVE_COLORS
 		 (!colored ? 0 :
       (cursor == i && hexOrAscii == 0 ? mark_color :
+      bufferAttr[i] & TAGGED ? 0 :
 		  buffer[i] == 0 ? (int) COLOR_PAIR(1) :
 		  buffer[i] < ' ' ? (int) COLOR_PAIR(2) :
 		  buffer[i] >= 127 ? (int) COLOR_PAIR(3) : 0)

--- a/hexedit.c
+++ b/hexedit.c
@@ -30,9 +30,10 @@ int sizeCopyBuffer, *bufferAttr;
 char *progName, *fileName, *baseName;
 unsigned char *buffer, *copyBuffer;
 typePage *edited;
+noteStruct *notes;
+size_t notes_size=NOTE_SIZE;
 
-char *lastFindFile = NULL, *lastYankToAFile = NULL, *lastAskHexString = NULL, *lastAskAsciiString = NULL, *lastFillWithStringHexa = NULL, *lastFillWithStringAscii = NULL;
-
+char *lastFindFile = NULL, *lastYankToAFile = NULL, *lastAskHexString = NULL, *lastAskAsciiString = NULL, *lastFillWithStringHexa = NULL, *lastFillWithStringAscii = NULL, *lastNote = NULL;
 
 const modeParams modes[LAST] = {
   { 8, 16, 256 },
@@ -53,6 +54,7 @@ const char * const usage = "usage: %s [-s | --sector] [-m | --maximize] [-l<n> |
 /*******************************************************************************/
 int main(int argc, char **argv)
 {
+
   progName = basename(argv[0]);
   argv++; argc--;
 
@@ -119,6 +121,7 @@ void init(void)
   hexOrAscii = TRUE;
   copyBuffer = NULL;
   edited = NULL;
+  notes = (noteStruct*) calloc(notes_size,sizeof(noteStruct));
 }
 
 void quit(void)
@@ -129,7 +132,10 @@ void quit(void)
   free(bufferAttr);
   FREE(copyBuffer);
   discardEdited();
-  FREE(lastFindFile); FREE(lastYankToAFile); FREE(lastAskHexString); FREE(lastAskAsciiString); FREE(lastFillWithStringHexa); FREE(lastFillWithStringAscii);
+  FREE(lastFindFile); FREE(lastYankToAFile); FREE(lastAskHexString); FREE(lastAskAsciiString); FREE(lastFillWithStringHexa); FREE(lastFillWithStringAscii); FREE(lastNote);
+  for (int i=0; i<notes_size; i++)
+    FREE(notes[i].note);
+  free(notes);
   exit(0);
 }
 

--- a/hexedit.c
+++ b/hexedit.c
@@ -31,7 +31,9 @@ char *progName, *fileName, *baseName;
 unsigned char *buffer, *copyBuffer;
 typePage *edited;
 noteStruct *notes;
-size_t notes_size=NOTE_SIZE;
+size_t notes_size = NOTE_SIZE;
+int tagFile = 0;
+FILE *tagfd;
 
 char *lastFindFile = NULL, *lastYankToAFile = NULL, *lastAskHexString = NULL, *lastAskAsciiString = NULL, *lastFillWithStringHexa = NULL, *lastFillWithStringAscii = NULL, *lastNote = NULL;
 
@@ -103,6 +105,7 @@ int main(int argc, char **argv)
     openFile();
   }
   readFile();
+  openTagFile();
   do display();
   while (key_to_function(getch()));
   quit();
@@ -136,6 +139,7 @@ void quit(void)
   for (int i=0; i<notes_size; i++)
     FREE(notes[i].note);
   free(notes);
+  fclose(tagfd);
   exit(0);
 }
 

--- a/hexedit.h
+++ b/hexedit.h
@@ -51,6 +51,7 @@
 #define NORMAL A_NORMAL
 #define MARKED A_REVERSE
 #define MODIFIED A_BOLD
+#define TAGGED A_STANDOUT
 #define ATTRPRINTW(attr, a) do { if (oldattr != (attr)) attrset(attr), oldattr = (attr); printw a; } while (0)
 #define MAXATTRPRINTW(attr, a) do { if (oldattr & (~(attr))) attrset(attr & oldattr), oldattr &= (attr); printw a; } while (0)
 #define PRINTW(a) ATTRPRINTW(NORMAL, a)

--- a/hexedit.h
+++ b/hexedit.h
@@ -102,7 +102,14 @@ extern char *progName, *fileName, *baseName;
 extern unsigned char *buffer, *copyBuffer;
 extern typePage *edited;
 
-extern char *lastFindFile, *lastYankToAFile, *lastAskHexString, *lastAskAsciiString, *lastFillWithStringHexa, *lastFillWithStringAscii;
+#define NOTE_SIZE 100
+typedef struct _noteStruct {
+  char *note;
+} noteStruct;
+extern noteStruct *notes;
+extern size_t notes_size;
+
+extern char *lastFindFile, *lastYankToAFile, *lastAskHexString, *lastAskAsciiString, *lastFillWithStringHexa, *lastFillWithStringAscii, *lastNote;
 
 
 /*******************************************************************************/

--- a/hexedit.h
+++ b/hexedit.h
@@ -109,6 +109,8 @@ typedef struct _noteStruct {
 } noteStruct;
 extern noteStruct *notes;
 extern size_t notes_size;
+extern int tagFile;
+extern FILE *tagfd;
 
 extern char *lastFindFile, *lastYankToAFile, *lastAskHexString, *lastAskAsciiString, *lastFillWithStringHexa, *lastFillWithStringAscii, *lastNote;
 
@@ -123,6 +125,9 @@ void quit(void);
 int tryloc(INT loc);
 void openFile(void);
 void readFile(void);
+void openTagFile(void);
+void readTagFile(void);
+void writeTagFile(void);
 int findFile(void);
 int computeLineSize(void);
 int computeCursorXCurrentPos(void);

--- a/interact.c
+++ b/interact.c
@@ -177,6 +177,51 @@ static void truncate_file(void)
   }
 }
 
+static void add_note(void)
+{
+  // Grow the notes buffer if we need to
+  if (base+cursor > notes_size) {
+    notes_size = base+cursor+NOTE_SIZE;
+    notes = (noteStruct*) realloc(notes,notes_size*sizeof(noteStruct));
+  }
+
+  char tmp[BLOCK_SEARCH_SIZE], msg[BLOCK_SEARCH_SIZE];
+
+  // Check if we're adding a new note or changing a existing note
+  if (notes[base+cursor].note) {
+    strlcpy(lastNote, notes[base+cursor].note, NOTE_SIZE);
+    snprintf(msg, BLOCK_SEARCH_SIZE, "Change the note for 0x%llx: ", base+cursor);
+  } else
+    snprintf(msg, BLOCK_SEARCH_SIZE, "Enter a note for 0x%llx: ", base+cursor);
+    free(notes[base+cursor].note);
+    notes[base+cursor].note = NULL;
+    notes[base+cursor].note = (char*) malloc(NOTE_SIZE);
+  char** last = &lastNote; 
+
+  if (!displayMessageAndGetString(msg, last, tmp, sizeof(tmp))) return;
+
+  // Overly paranoid, but clear the note before copying it in
+  memset(notes[base+cursor].note,'\0',NOTE_SIZE);
+  strlcpy(notes[base+cursor].note,tmp,NOTE_SIZE);
+}
+
+static void get_note(void)
+{
+  if (notes[base+cursor].note)
+    displayMessageAndWaitForKey(notes[base+cursor].note);
+  else
+    displayMessageAndWaitForKey("No note set for current position!");
+}
+
+static void delete_note(void)
+{
+  if (notes[base+cursor].note) {
+    free(notes[base+cursor].note);
+    notes[base+cursor].note = NULL;
+    displayMessageAndWaitForKey("Note deleted");
+  }
+}
+
 static void firstTimeHelp(void)
 {
   static int firstTime = TRUE;
@@ -609,6 +654,18 @@ static void escaped_command(void)
 
   case 't':
     truncate_file();
+    break;
+
+  case 'o':
+    add_note();
+    break;
+
+  case 'g':
+    get_note();
+    break;
+
+  case 'd':
+    delete_note();
     break;
 
   case '':


### PR DESCRIPTION
This adds the ability to set notes for certain bytes, and to mark bytes or ranges of bytes with custom colours. This is particularly useful when trying to understand a binary format.

These are interactive functions:

Esc-c - prompt to mark a byte or mark'ed range of bytes as one of three colours
Esc-o - add a custom note to a byte. It will be displayed in the status line when the cursor is on the byte
Esc-d - delete a note
Esc-g - display a note
Esc-s - write the colour and note markup to a tag file (more on that below)

Markup can be persisted to a simple tag file with the following format:
<byte location> n: <note free text>
<byte location> c: <colour number 1-3> <number of bytes to colour>
colour number is 1 - cyan, 2 - magenta, 3 - yellow

For example, a tag file marking up the first two fields of an ELF file in colour and with notes would look like:
```
0x0 c: 1 4
0x0 n: ELF Magic Bytes
0x4 c: 2 1
0x4 n: 1 - 32bit 2 - 64bit
```

Tag files are written to the currently edited filename with ".tags" appended