### PR TITLE
Some trivial fixes to please static code analyzers

### DIFF
--- a/file.c
+++ b/file.c
@@ -90,7 +90,10 @@ int findFile(void)
   char *p, tmp[BLOCK_SEARCH_SIZE];
   p = lastFindFile ? strdup(lastFindFile) : NULL;
   if (!displayMessageAndGetString("File name: ", &p, tmp, sizeof(tmp))) return FALSE;
-  if (!is_file(tmp)) return FALSE;
+  if (!is_file(tmp)) {
+    FREE(p);
+    return FALSE;
+  }
   FREE(lastFindFile); lastFindFile = fileName;
   fileName = p;
   return TRUE;

--- a/mark.c
+++ b/mark.c
@@ -112,6 +112,10 @@ void fill_with_string(void)
     } else if (!hexStringToBinString(tmp2, &l2)) return;
   }
   tmp1 = malloc(l1);
+  if (!tmp1) {
+    displayMessageAndWaitForKey("Can't allocate memory");
+    return;
+  }
   for (i = 0; i < l1 - l2 + 1; i += l2) memcpy(tmp1 + i, tmp2, l2);
   memcpy(tmp1 + i, tmp2, l1 - i);
   addToEdited(mark_min, l1, tmp1);

--- a/search.c
+++ b/search.c
@@ -34,6 +34,10 @@ static int searchA(char **string, int *sizea, char *tmp, int tmp_size)
   if (hexOrAscii) if (!hexStringToBinString(tmp, sizea)) return FALSE;
 
   *string = malloc(*sizea);
+  if (!*string) {
+    displayMessageAndWaitForKey("Can't allocate memory");
+    return FALSE;
+  }
   memcpy(*string, tmp, *sizea);
 
   nodelay(stdscr, TRUE);


### PR DESCRIPTION
Some code analyzers complain about possible memory leaks and missing NULL checks after malloc in hexedit.
Here are some fixes to these issues.