### PR TITLE
Add CI test

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -1,0 +1,27 @@
+name: full-check
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install_dependencies
+      run: sudo apt install libncurses5-dev
+    - name: first_build
+      run: |
+           ./autogen.sh
+           ./configure
+           make
+           sudo make install
+#           sudo make uninstall
+#           make distclean
+#    - name: second_build_to_test_build_twice
+#      run: |
+#           ./autogen.sh
+#           ./configure
+#           make
+#           sudo make install

--- a/configure.ac
+++ b/configure.ac
@@ -3,9 +3,10 @@ dnl
 dnl Process this file with autoconf to produce a configure script.
 dnl
 
-AC_PREREQ(2.50)
+AC_PREREQ([2.69])
 
-AC_INIT(hexedit.c)
+AC_INIT
+AC_CONFIG_SRCDIR([hexedit.c])
 AC_CONFIG_HEADERS(config.h)
 
 define(TheVERSION, 1.5)
@@ -48,7 +49,7 @@ dnl whether functions and headers are available, whether they work, etc.
 AC_SYS_LARGEFILE
 
 dnl Checks for header files.
-AC_HEADER_STDC
+AC_PROG_EGREP
 AC_HEADER_STAT
 AC_HEADER_SYS_WAIT
 AC_CHECK_HEADERS(fcntl.h unistd.h libgen.h sys/mount.h)
@@ -72,4 +73,5 @@ $ac_includes_default
 #endif
 )
 
-AC_OUTPUT(Makefile Makefile-build hexedit.1)
+AC_CONFIG_FILES([Makefile Makefile-build hexedit.1])
+AC_OUTPUT


### PR DESCRIPTION
It will run after each push to test an initial build, install and uninstall. After this a distclean and a second build and install will run to test if these actions execute twice. Any error in source code will break the build and invalidate the CI test.
    
Currently, part of the test is disabled because the uninstall target doesn't exist yet.
