### PR TITLE
Add uninstall target

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -1,0 +1,27 @@
+name: full-check
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install_dependencies
+      run: sudo apt install libncurses5-dev
+    - name: first_build
+      run: |
+           ./autogen.sh
+           ./configure
+           make
+           sudo make install
+#           sudo make uninstall
+#           make distclean
+#    - name: second_build_to_test_build_twice
+#      run: |
+#           ./autogen.sh
+#           ./configure
+#           make
+#           sudo make install

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -25,3 +25,6 @@ jobs:
            ./configure
            make
            sudo make install
+    - name: run_hexedit_to_show_version
+      run: |
+           hexedit -v 2>&1 | grep maximize

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -17,11 +17,11 @@ jobs:
            ./configure
            make
            sudo make install
-#           sudo make uninstall
-#           make distclean
-#    - name: second_build_to_test_build_twice
-#      run: |
-#           ./autogen.sh
-#           ./configure
-#           make
-#           sudo make install
+           sudo make uninstall
+           make distclean
+    - name: second_build_to_test_build_twice
+      run: |
+           ./autogen.sh
+           ./configure
+           make
+           sudo make install

--- a/Makefile.in
+++ b/Makefile.in
@@ -46,3 +46,7 @@ install: $(PRODUCT)
 	$(INSTALL) -m 755 $(PRODUCT) $(DESTDIR)$(bindir)
 	$(INSTALL) -d -m 755 $(DESTDIR)$(mandir)/man1
 	$(INSTALL) -m 644 $(PRODUCT).1 $(DESTDIR)$(mandir)/man1
+
+uninstall:
+	test -f $(DESTDIR)$(bindir)/$(PRODUCT) && rm -f $(DESTDIR)$(bindir)/$(PRODUCT)
+	test -f $(DESTDIR)$(mandir)/man1/$(PRODUCT).1 && rm -r $(DESTDIR)$(mandir)/man1/$(PRODUCT).1

--- a/configure.ac
+++ b/configure.ac
@@ -3,9 +3,10 @@ dnl
 dnl Process this file with autoconf to produce a configure script.
 dnl
 
-AC_PREREQ(2.50)
+AC_PREREQ([2.69])
 
-AC_INIT(hexedit.c)
+AC_INIT
+AC_CONFIG_SRCDIR([hexedit.c])
 AC_CONFIG_HEADERS(config.h)
 
 define(TheVERSION, 1.5)
@@ -48,7 +49,7 @@ dnl whether functions and headers are available, whether they work, etc.
 AC_SYS_LARGEFILE
 
 dnl Checks for header files.
-AC_HEADER_STDC
+AC_PROG_EGREP
 AC_HEADER_STAT
 AC_HEADER_SYS_WAIT
 AC_CHECK_HEADERS(fcntl.h unistd.h libgen.h sys/mount.h)
@@ -72,4 +73,5 @@ $ac_includes_default
 #endif
 )
 
-AC_OUTPUT(Makefile Makefile-build hexedit.1)
+AC_CONFIG_FILES([Makefile Makefile-build hexedit.1])
+AC_OUTPUT


### PR DESCRIPTION
This PR depends of #54.

This PR will add uninstall target and improve the CI tests:
  - Enable uninstall test
  - Consequently, allow the CI test to build twice
  - Execute 'hexedit -v' to make a superficial test
 
