### PR TITLE
Move SIGWINCH handling from handler to NCURSES

### DIFF
--- a/display.c
+++ b/display.c
@@ -100,29 +100,11 @@ int computeCursorXPos(int cursor, int hexOrAscii)
 /*******************************************************************************/
 /* Curses functions */
 /*******************************************************************************/
-static void handleSigWinch(int sig)
-{
-  /*Close and refresh window to get new size*/
-  endwin();
-  refresh();
-
-  /*Reset to trigger recalculation*/
-  lineLength = 0;
-
-  clear();
-  initDisplay();
-  readFile();
-  display();
-}
 
 void initCurses(void)
 {
   struct sigaction sa;
   initscr();
-
-  memset(&sa, 0, sizeof(struct sigaction));
-  sa.sa_handler = handleSigWinch;
-  sigaction(SIGWINCH, &sa, NULL);
 
 #ifdef HAVE_COLORS
   if (colored) {

--- a/interact.c
+++ b/interact.c
@@ -341,9 +341,21 @@ int key_to_function(int key)
 
   switch (key)
     {
-    case ERR:
     case KEY_RESIZE:
-      /*no-op*/
+      /*Close and refresh window to get new size*/
+      endwin();
+      refresh();
+
+      /*Reset to trigger recalculation*/
+      lineLength = 0;
+
+      clear();
+      initDisplay();
+      readFile();
+      display();
+      break;
+
+    case ERR:
       break;
 
     case KEY_RIGHT:


### PR DESCRIPTION
Use NCURSES internal SIGWINCH handling to generate KEY_RESIZE.
Use KEY_RESIZE to trigger window resize instead of SIGWINCH.

This fixes a crash on some platforms during resize introduced
in b622084ac - it's not safe to allocate or reallocate memory
during a signal handler.

fixes #51