### PR TITLE
extend size of address when file is larger than 4GB

### DIFF
--- a/display.c
+++ b/display.c
@@ -164,7 +164,7 @@ void exitCurses(void)
 
 static void printaddr(uint64_t addr)
 {
-  char templ[7];
+  char templ[7]; // maximum string is "%016lX", which is 6 chars + 1 null byte
   sprintf(templ,"%%0%dlX", nAddrDigits);
   PRINTW((templ, addr));
 }

--- a/display.c
+++ b/display.c
@@ -84,7 +84,7 @@ int computeLineSize(void) { return computeCursorXPos(lineLength - 1, 0) + 1; }
 int computeCursorXCurrentPos(void) { return computeCursorXPos(cursor, hexOrAscii); }
 int computeCursorXPos(int cursor, int hexOrAscii)
 {
-  int r = 11;
+  int r = nAddrDigits + 3;
   int x = cursor % lineLength;
   int h = (hexOrAscii ? x : lineLength - 1);
 
@@ -162,6 +162,13 @@ void exitCurses(void)
   endwin();
 }
 
+static void printaddr(uint64_t addr)
+{
+  char templ[7];
+  sprintf(templ,"%%0%dlX", nAddrDigits);
+  PRINTW((templ, addr));
+}
+
 void display(void)
 {
   long long fsize;
@@ -176,7 +183,7 @@ void display(void)
     move(i / lineLength, 0);
     for (j = 0; j < colsUsed; j++) printw(" "); /* cleanup the line */
     move(i / lineLength, 0);
-    PRINTW(("%08lX", (int) (base + i)));
+    printaddr(base+i);
   }
 
   attrset(NORMAL);
@@ -201,7 +208,8 @@ void displayLine(int offset, int max)
 #ifdef HAVE_COLORS
   mark_color = COLOR_PAIR(4) | A_BOLD;
 #endif
-  PRINTW(("%08lX   ", (int) (base + offset)));
+  printaddr(base + offset);
+  PRINTW(("   "));
   for (i = offset; i < offset + lineLength; i++) {
     if (i > offset) MAXATTRPRINTW(bufferAttr[i] & MARKED, (((i - offset) % blocSize) ? " " : "  "));
     if (i < max) {

--- a/file.c
+++ b/file.c
@@ -53,6 +53,18 @@ void openFile(void)
       fileSize = 0;
   }
   biggestLoc = fileSize;
+
+  // compute number of digits for address
+
+  nAddrDigits=8;
+  off_t maxAddr = biggestLoc;
+  if (maxAddr > 0xFFFFFFFF) {
+    maxAddr >>= 32;
+    while (maxAddr) {
+      nAddrDigits+=2;
+      maxAddr >>= 8;
+    }
+  }
 }
 
 void readFile(void)

--- a/file.c
+++ b/file.c
@@ -16,6 +16,26 @@
    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.*/
 #include "hexedit.h"
 
+
+// Compute number of hex-digits needed to display an address.
+// We only increase this by full bytes (2 digits).
+// Because the input is uint64_t, the maximum result is 16 (64bit = 16*4bit).
+int compute_nDigits(uint64_t maxAddr)
+{
+  int digits = 0;
+  while (maxAddr) {
+    digits+=2;
+    maxAddr >>= 8;
+  }
+
+  if (digits==0) {
+    return 2;
+  }
+
+  return digits;
+}
+
+
 void openFile(void)
 {
   struct stat st;
@@ -54,16 +74,11 @@ void openFile(void)
   }
   biggestLoc = fileSize;
 
-  // compute number of digits for address
+  nAddrDigits = compute_nDigits(biggestLoc);
 
-  nAddrDigits=8;
-  off_t maxAddr = biggestLoc;
-  if (maxAddr > 0xFFFFFFFF) {
-    maxAddr >>= 32;
-    while (maxAddr) {
-      nAddrDigits+=2;
-      maxAddr >>= 8;
-    }
+  // use at least 8 digits (4 byte addresses)
+  if (nAddrDigits < 8) {
+    nAddrDigits = 8;
   }
 }
 

--- a/hexedit.c
+++ b/hexedit.c
@@ -26,6 +26,7 @@ INT base, oldbase;
 int normalSpaces, cursor, cursorOffset, hexOrAscii;
 int cursor, blocSize, lineLength, colsUsed, page;
 int fd, nbBytes, oldcursor, oldattr, oldcursorOffset;
+int nAddrDigits;
 int sizeCopyBuffer, *bufferAttr;
 char *progName, *fileName, *baseName;
 unsigned char *buffer, *copyBuffer;

--- a/hexedit.h
+++ b/hexedit.h
@@ -97,6 +97,7 @@ extern INT base, oldbase;
 extern int normalSpaces, cursor, cursorOffset, hexOrAscii;
 extern int cursor, blocSize, lineLength, colsUsed, page;
 extern int isReadOnly, fd, nbBytes, oldcursor, oldattr, oldcursorOffset;
+extern int nAddrDigits;
 extern int sizeCopyBuffer, *bufferAttr;
 extern char *progName, *fileName, *baseName;
 extern unsigned char *buffer, *copyBuffer;


### PR DESCRIPTION
When the file size exceeds 4GB, the current 8 digits are not enough for the address and the display overflows.
This patch fixes #68.
